### PR TITLE
Fix checking with another proxy if the current one failed

### DIFF
--- a/controllers/report.ctrl.php
+++ b/controllers/report.ctrl.php
@@ -779,26 +779,26 @@ class ReportController extends Controller {
 			// update crawl log
 			$logId = $result['log_id'];
 			$crawlLogCtrl->updateCrawlLog($logId, $crawlInfo);
-			
-		}
 		
-		// if proxy enabled if crawl failed try to check next item
-		if (!$crawlResult[$seInfoId]['status'] && SP_ENABLE_PROXY && CHECK_WITH_ANOTHER_PROXY_IF_FAILED) {
-			
-			// max proxy checked in one execution is exeeded
-			if ($this->proxyCheckCount < CHECK_MAX_PROXY_COUNT_IF_FAILED) {
-			
-				// if proxy is available for execution
-				$proxyCtrler = New ProxyController();
-				if ($proxyInfo = $proxyCtrler->getRandomProxy()) {
-					$this->proxyCheckCount++;
-					sleep(SP_CRAWL_DELAY);
-					$crawlResult = $this->crawlKeyword($keywordInfo, $seInfoId, $cron, $removeDuplicate);		
-				}
+			// if proxy enabled if crawl failed try to check next item
+			if (!$crawlResult[$seInfoId]['status'] && SP_ENABLE_PROXY && CHECK_WITH_ANOTHER_PROXY_IF_FAILED) {
 				
-			} else {
-				$this->proxyCheckCount = 1;
+				// max proxy checked in one execution is exeeded
+				if ($this->proxyCheckCount < CHECK_MAX_PROXY_COUNT_IF_FAILED) {
+				
+					// if proxy is available for execution
+					$proxyCtrler = New ProxyController();
+					if ($proxyInfo = $proxyCtrler->getRandomProxy()) {
+						$this->proxyCheckCount++;
+						sleep(SP_CRAWL_DELAY);
+						$crawlResult = array_merge($crawlResult, $this->crawlKeyword($keywordInfo, $seInfoId, $cron, $removeDuplicate));
+					}
+					
+				} else {
+					$this->proxyCheckCount = 1;
+				}
 			}
+		
 		}
 		
 		return  $crawlResult;


### PR DESCRIPTION
Currently this section uses $seInfoId outside of the for loop where
$seInfoId is instantiated. This means proxy failure checking probably
isn’t occurring at all.

Previously (v3.8 I think) this section used $seId instead of $seInfoId,
which works great when you’re checking keywords for a single search
engine, but if you’re generating results for multiple search engines at
a time, it would fail.

By moving the proxy failure check to exist within the search engine
iterative loop, we check for proxy failure after _each_ search engine
crawl then merge the results into a final return array that includes
all search engines.

Note that logging remains on a per-search/crawl (not per-success) basis, which is essential for debugging and tracking purposes.
