### PR TITLE
Repairs infinite loop

### DIFF
--- a/controllers/siteauditor.ctrl.php
+++ b/controllers/siteauditor.ctrl.php
@@ -378,7 +378,7 @@ class SiteAuditorController extends Controller{
 	        if (!$crawlUrl = $this->getProjectRandomUrl($projectId)) {
 	            $completed = 1;
 	        } else {
-	            if (!$this->cron) updateJsLocation('crawling_url', $reportUrl);
+	            if (!$this->cron) updateJsLocation('crawling_url', $crawledUrl);
 	        }	        
 	    } else {
 	        $completed = 1;
@@ -395,7 +395,7 @@ class SiteAuditorController extends Controller{
     	    $this->set('projectInfo', $projectInfo);
     	    $this->render('siteauditor/runproject');
 	    } else {
-	        return $reportUrl;
+	        return $crawledUrl;
 	    }
 	}
     


### PR DESCRIPTION
In my tests this repairs the loop issue found while testing my redirect detection code against seopanel.in

The loop would occur if the project URL is configured to a value that
didn’t match the effective crawled URL (i.e.: www. in one spot and no
www in the other).