### PR TITLE
Add plaintext email options for multipart messages

### DIFF
--- a/includes/sp-common.php
+++ b/includes/sp-common.php
@@ -400,6 +400,8 @@ function sendMail($from, $fromName, $to ,$subject,$content, $attachment = ''){
 
 	$mail->Subject = $subject;
 	$mail->Body = $content;
+	$mail->msgHTML($content); //creates plaintext alternate automatically
+	$mail->AltBody = 'To view the message, please use an HTML compatible email viewer!'; //fallback
 	
 	// if attachments are there
 	if (!empty($attachment)) {


### PR DESCRIPTION
This enables multipart messages using standard PHPMailer methods to
prevent high Spamassassin scores from rule TO_NO_BRKTS_HTML_ONLY

Fixes Issue #67