### PR TITLE
Trim whitespace from URL when adding website

### DIFF
--- a/includes/sp-common.php
+++ b/includes/sp-common.php
@@ -207,7 +207,7 @@ function formatDate($date) {
 
 function addHttpToUrl($url){
 	if(!stristr($url, 'http://') && !stristr($url, 'https://')){
-		$url = 'http://'.$url;
+		$url = 'http://'.trim($url);
 	}
 	return $url;
 }


### PR DESCRIPTION
This seems like the best place to do it so that it's consistent throughout SEO Panel. Alternate location would probably be: website.ctrl.php:240

Unless trailing slashes also need to be stripped (which I haven't confirmed), this should resolve #113 