### PR TITLE
Properly silence this logging unless debug mode is on.

### DIFF
--- a/controllers/report.ctrl.php
+++ b/controllers/report.ctrl.php
@@ -682,11 +682,11 @@ class ReportController extends Controller {
 			
 			$seStart = $this->seList[$seInfoId]['start'] + $this->seList[$seInfoId]['start_offset'];
 			while(empty($result['error']) && ($seStart < $this->seList[$seInfoId]['max_results']) ){
-				$logId = $result['log_id'];
 				if(SP_DEBUG){
+					$logId = $result['log_id'];
 					$crawlInfo['log_message'] = "Started at: $seStart";
+					$crawlLogCtrl->updateCrawlLog($logId, $crawlInfo);
 				}
-				$crawlLogCtrl->updateCrawlLog($logId, $crawlInfo);
 				sleep(SP_CRAWL_DELAY);
 				$seUrl = str_replace('[--start--]', $seStart, $searchUrl);
 				$result = $this->spider->getContent($seUrl);


### PR DESCRIPTION
This line was rather important to include in the SP_DEBUG conditional: `$crawlLogCtrl->updateCrawlLog($logId, $crawlInfo);`

I left it out with the last pull request. This should actually resolve this now. Apologies for the extra PR.

Overview: when debugging crawling issues I wasn't sure when the crawler had moved on to the next 'page' of results (particularly for Bing/MSN search engine), so I added this logging in to ensure I could monitor that. It's handy to have for debugging, but not necessary for general usage.