### PR TITLE
Fix GA sync (decommissioned Universal Analytics API) and CSV import MIME check

### DIFF
--- a/controllers/googleapi.ctrl.php
+++ b/controllers/googleapi.ctrl.php
@@ -240,36 +240,27 @@ class GoogleAPIController extends Controller{
 	        return [FALSE, $websites, $client];
 	    }
 	    
-	    // Create a Google_Service_Analytics object
-	    $analytics = new Google_Service_Analytics($client);	    
-	    
-	    // Retrieve the list of accounts
-	    $accounts = $analytics->management_accounts->listManagementAccounts();
-	    
-	    // Loop through the accounts
-	    foreach ($accounts->getItems() as $account) {
-	        // Get the account ID and name
-	        $accountId = $account->getId();
-	        $accountName = $account->getName();
-	        
-	        // get analytics admin properties
-	        $accessToken = $this->__getAccessToken($client);
-	        $apiUrl = "https://analyticsadmin.googleapis.com/v1alpha/properties?filter=parent:accounts/$accountId";
-	        $ret = $this->plainAPICall($apiUrl, $accessToken);	        
-	        if (!empty($ret['error'])) {
-	            continue;
-	        }
-	        
-	        if (!empty($ret['page']['properties'])) {	            
-	            foreach ($ret['page']['properties'] as $property) {
-	                $propertyId = str_replace("properties/", "", $property['name']);
-	                $propertyName = $property['displayName'];
-	                $websites[] = array(
-	                    'account_name' => $accountName,
-	                    'account_id' => $accountId,
-	                    'property_name' => $propertyName,
-	                    'property_id' => $propertyId,
-	                );
+	    // GA4 Admin API: list accounts + properties in ONE call (UA analytics/v3 was decommissioned 2024-07)
+	    $accessToken = $this->__getAccessToken($client);
+	    $apiUrl = "https://analyticsadmin.googleapis.com/v1beta/accountSummaries?pageSize=200";
+	    $ret = $this->plainAPICall($apiUrl, $accessToken);
+	    if (!empty($ret['error'])) {
+	        return [FALSE, $websites, $ret['errmsg']];
+	    }
+	    if (!empty($ret['page']['accountSummaries'])) {
+	        foreach ($ret['page']['accountSummaries'] as $acc) {
+	            $accountId = str_replace("accounts/", "", $acc['account']);
+	            $accountName = $acc['displayName'];
+	            if (!empty($acc['propertySummaries'])) {
+	                foreach ($acc['propertySummaries'] as $prop) {
+	                    $propertyId = str_replace("properties/", "", $prop['property']);
+	                    $websites[] = array(
+	                        'account_name' => $accountName,
+	                        'account_id' => $accountId,
+	                        'property_name' => $prop['displayName'],
+	                        'property_id' => $propertyId,
+	                    );
+	                }
 	            }
 	        }
 	    }

--- a/controllers/website.ctrl.php
+++ b/controllers/website.ctrl.php
@@ -704,7 +704,8 @@ class WebsiteController extends Controller{
 		}
 		
 		// if csv file is not uploaded
-		if (mime_content_type($_FILES['website_csv_file']['tmp_name']) != 'text/plain') {
+		$spCsvMime = mime_content_type($_FILES['website_csv_file']['tmp_name']);
+		if (!in_array($spCsvMime, array('text/plain', 'text/csv', 'application/csv', 'application/vnd.ms-excel'))) {
 		    print "<script>alert('".$this->spTextWeb['Please enter CSV file']."')</script>";
 		    return False;
 		}


### PR DESCRIPTION
Fixes #252 — two outdated-API breakages on `develop` (SEO Panel 6.0.0, PHP 8.2).

### 1. Google Analytics sync — `controllers/googleapi.ctrl.php`
`getanalyticWebsitesPropertyIds()` listed accounts via the **Universal Analytics Management API** (`Google_Service_Analytics->management_accounts->listManagementAccounts()`), which Google decommissioned on **2024-07-01**. The call throws an uncaught exception → output buffering discards it → the endpoint returns an empty body → the UI shows `API Error: SyntaxError: Unexpected end of JSON input`.

Replaced with a single **GA4 Admin API** call to `accountSummaries` (`analyticsadmin.googleapis.com/v1beta/accountSummaries`), which returns account + property summaries together. Uses the existing `analytics.readonly` scope; requires the Google Analytics Admin API enabled.

### 2. CSV website import — `controllers/website.ctrl.php`
`importWebsiteFromCsv()` required `mime_content_type()` to equal exactly `text/plain`, so real `.csv` files (usually detected as `text/csv`) were always rejected with "Please enter CSV file". Now accepts the common CSV MIME types, consistent with the `$fileInfo["type"]` check later in the same function.

### Testing
Tested on 6.0.0 / PHP 8.2 against a live Google account: GA4 sync now returns all properties correctly, and CSV import completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
